### PR TITLE
Make the cmake exported interface more modern

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/jsoncpp>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib_json>
-        $<INSTALL_INTERFACE:include>)
+        $<INSTALL_INTERFACE:${HEADER_INSTALL_DIR}>)
 
 export_api(jsoncpp JSON_API)
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -8,18 +8,22 @@ set(sources
     json_value.cpp
     json_writer.cpp)
 
-include_directories("${PROJECT_SOURCE_DIR}/include/jsoncpp")
-include_directories("${PROJECT_SOURCE_DIR}/src/lib_json")
-
 add_compiler_flags()
 
 add_library(jsoncpp SHARED ${sources} ${headers})
 
+target_include_directories(
+    jsoncpp
+    PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/jsoncpp>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/lib_json>
+        $<INSTALL_INTERFACE:include>)
+
 export_api(jsoncpp JSON_API)
 
-install_config(
+generate_and_install_config(
     NAME JsonCpp
-    TARGET jsoncpp)
+    TARGETS jsoncpp)
 
 install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/jsoncpp"


### PR DESCRIPTION
BST-203
http://jira.makerbot.net/browse/BST-203

This is an attempt to address the problem of repos depending on their installed
headers before their local headers. The way install_config sets include_dirs
in the *Config.cmake is sort of anti-social. We probably shouldn't be using
include_directories anywhere, really, since we can use target_include_dirs
instead.
