### PR TITLE
force builder cmake and shebang to python 2

### DIFF
--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories("${PROJECT_SOURCE_DIR}/include/jsoncpp")
 include_directories("${PROJECT_SOURCE_DIR}/src/lib_json")
 include_directories("${PROJECT_SOURCE_DIR}/jsontestrunner")
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 2 EXACT)
 
 add_executable(jsontestrunner main.cpp)
 use_standard_flags(jsontestrunner)

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories("${PROJECT_SOURCE_DIR}/include/jsoncpp")
 include_directories("${PROJECT_SOURCE_DIR}/test_lib_json")
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 2 EXACT)
 
 add_executable(test_lib_json jsontest.cpp main.cpp)
 use_standard_flags(test_lib_json)


### PR DESCRIPTION
This package actually requires version 2 of python to compile correctly.